### PR TITLE
119-correct-apikey-link

### DIFF
--- a/docs/pages/documentation/starters/dotnet-starter.md
+++ b/docs/pages/documentation/starters/dotnet-starter.md
@@ -5,7 +5,7 @@ title: Utilisation de C#
 
 Ce guide décrit comment intégrer l'API à un projet .Net Core.
 
-Si vous n'avez pas de clé d'API, veuillez suivre la procédure décrite [ici]({{ '/pages/quick-start/readme' | relative_url}}).
+Si vous n'avez pas de clé d'API, veuillez suivre la procédure décrite [ici]({{ '/pages/quick-start/quick-start.html' | relative_url}}).
 
 NOTE| Dans nos différents exemples, nous utilisons maven et la librairie développée par Firely Hl7.Fhir.R4. FHIR reste une API HTTP JSON/XML  qui pourra être appelée avec d'autres techniques.
 

--- a/docs/pages/documentation/starters/java-starter.md
+++ b/docs/pages/documentation/starters/java-starter.md
@@ -5,7 +5,7 @@ title: Utilisation de Java
 
 Ce guide décrit comment intégrer l'API à un projet Java.
 
-Si vous n'avez pas de clé d'API, veuillez suivre la procédure décrite [ici]({{ '/pages/quick-start/readme' | relative_url}}).
+Si vous n'avez pas de clé d'API, veuillez suivre la procédure décrite [ici]({{ '/pages/quick-start/quick-start.html' | relative_url}}).
 
 NOTE| Dans nos différents exemples, nous utilisons maven et la librairie Hapi. FHIR reste une API HTTP JSON/XML  qui pourra être appelée avec d'autres techniques.
 

--- a/docs/pages/documentation/starters/php-starter.md
+++ b/docs/pages/documentation/starters/php-starter.md
@@ -5,7 +5,7 @@ title: Utilisation de PHP
 
 Ce guide décrit comment intégrer l'API à un projet PHP.
 
-Si vous n'avez pas de clé d'API, veuillez suivre la procédure décrite [ici]({{ '/pages/quick-start/readme' | relative_url}}).
+Si vous n'avez pas de clé d'API, veuillez suivre la procédure décrite [ici]({{ '/pages/quick-start/quick-start.html' | relative_url}}).
 
 NOTE| Dans nos différents exemples, nous utilisons composer et la librairie dcarbone/php-fhir pour FHIR et Guzzle pour le REST. FHIR reste une API HTTP JSON/XML  qui pourra être appelée avec d'autres techniques.
 


### PR DESCRIPTION
correct apikey link in java-starter | php-starter | dotnet.starter