### PR TITLE
[Narratif] Mise à jour rubrique suppression d'une ressource

### DIFF
--- a/docs/pages/quick-start/api-basics.md
+++ b/docs/pages/quick-start/api-basics.md
@@ -147,6 +147,18 @@ Seul le lien Next est supporté.
 
 De manière générale, la ressource n'est plus publiée dans l'API à partir du moment où elle devient inactive. Cependant, elle ne disparait pas complétement de l'API puisqu'elle reste présente dans le delta avec uniquement son id et le champs active = false (device : status inactive). Ce fonctionnement permet notamment aux consommateurs du delta d'isoler les ressources supprimées entre deux dates (synchronisations).
 
+Par défaut, l'API remonte toutes les ressources (actives et inactives). 
+Pour exlcure les ressources inactives du résulat, utilisez le filtre active=true.
+
+Exemple : 
+```json
+
+GET ../Organization // la requête remonte les structures ouvertes et fermées
+GET ../Organization?active=true // la requête ne remonte que les structures ouvertes
+GET ../Organization?active=false // la requête ne remonte que les structures fermées
+
+```
+
 <div class="wysiwyg"  markdown="1">
 - active=false pour l'ensemble des ressources excepté Device (exemple : [api-url]/Practitioner?active=false)
 - status=false pour Device (exemple : [api-url]/Device?status=inactive)


### PR DESCRIPTION
mise à jour de la rubrique "suppression d'une ressource" pour indiquer que par défaut l'API remonte les ressources actives et inactives